### PR TITLE
fix: remove option from `unicorn/number-literal-case` rule

### DIFF
--- a/.changeset/itchy-goats-change.md
+++ b/.changeset/itchy-goats-change.md
@@ -1,0 +1,7 @@
+---
+"@arphi/eslint-config": patch
+---
+
+Fixes a rule triggering an ESLint validation failure.
+
+The `unicorn/number-literal-case` rule [should accept an option](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/number-literal-case.md) but the rule seems bugged. When `prettier` is not set to `true`, the rule is not deactivated so ESLint will fail to validate the rule.

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -121,10 +121,8 @@ export function unicorn(rulesOverrides: RulesOverrides = {}): Config[] {
         "unicorn/no-useless-switch-case": "error",
         "unicorn/no-useless-undefined": "off",
         "unicorn/no-zero-fractions": "error",
-        "unicorn/number-literal-case": [
-          "error",
-          { hexadecimalValue: "uppercase" },
-        ],
+        /* This rule should accept an option but the rule validation fails... Since we're using the default value it should be safe to remove the option.*/
+        "unicorn/number-literal-case": "error",
         "unicorn/numeric-separators-style": [
           "error",
           {


### PR DESCRIPTION
## Changes

Removes the option for the `unicorn/number-literal-case` rule.

The `unicorn/number-literal-case` rule [should accept an option](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/number-literal-case.md) but the rule seems bugged. When `prettier` is not set to `true`, the rule is not deactivated so ESLint will fail to validate the rule.

Since we're using the default value, it should be safe to just use `error`.

## Tests

Manually on another project by overriding the rule. So it should work as expected this time.

## Docs

Changeset added.