### PR TITLE
fix(eslint-config): load prettier conditionally

### DIFF
--- a/.changeset/afraid-ties-happen.md
+++ b/.changeset/afraid-ties-happen.md
@@ -1,0 +1,5 @@
+---
+"@arphi/eslint-config": patch
+---
+
+Fixes an issue where the `eslint-config-prettier` package were loaded even when Prettier is not enabled.

--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
     "prettier": "3.5.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@arphi/eslint-config": "link:packages/eslint-config"
+    }
   }
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -88,7 +88,7 @@ npm i -D eslint-plugin-jsdoc
 
 #### Prettier
 
-If you use Prettier you should pass the following flag to disable some rules that might be conflicting with Prettier:
+Some rules might be conflicting with Prettier. If you're using Prettier and notice some conflicts, instead of overriding the rules manually you can enable the Prettier flag:
 
 ```js
 import arphi from "@arphi/eslint-config";

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -86,11 +86,9 @@ The configuration for JSDoc uses the following plugins, you might need to instal
 npm i -D eslint-plugin-jsdoc
 ```
 
-See also: [Typescript](#typescript)
-
 #### Prettier
 
-If you use Prettier you should pass the following flag:
+If you use Prettier you should pass the following flag to disable some rules that might be conflicting with Prettier:
 
 ```js
 import arphi from "@arphi/eslint-config";
@@ -98,7 +96,11 @@ import arphi from "@arphi/eslint-config";
 export default arphi({ prettier: true });
 ```
 
-This will disable some rules that might be conflicting with Prettier.
+The configuration for Prettier uses the following plugin, you might need to install it:
+
+```sh
+npm i -D eslint-config-prettier
+```
 
 #### Tests
 

--- a/packages/eslint-config/src/configs/prettier.ts
+++ b/packages/eslint-config/src/configs/prettier.ts
@@ -9,7 +9,7 @@ import type { Config, RulesOverrides } from "../types";
 export async function prettier(
   rulesOverrides: RulesOverrides = {}
 ): Promise<Config[]> {
-  const prettierConfig = await import("eslint-config-prettier");
+  const { default: prettierConfig } = await import("eslint-config-prettier");
 
   return [
     {

--- a/packages/eslint-config/src/configs/prettier.ts
+++ b/packages/eslint-config/src/configs/prettier.ts
@@ -1,13 +1,16 @@
-import prettierConfig from "eslint-config-prettier";
 import type { Config, RulesOverrides } from "../types";
 
 /**
  * Configure the Prettier rules.
  *
  * @param {RulesOverrides} [rulesOverrides] - The rules to override.
- * @returns {Config[]} The Prettier configuration.
+ * @returns {Promise<Config[]>} The Prettier configuration.
  */
-export function prettier(rulesOverrides: RulesOverrides = {}): Config[] {
+export async function prettier(
+  rulesOverrides: RulesOverrides = {}
+): Promise<Config[]> {
+  const prettierConfig = await import("eslint-config-prettier");
+
   return [
     {
       ...prettierConfig,

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -92,7 +92,7 @@ async function loadFooterConfigs(
     enablePrettier ? prettier(overrides?.prettier) : [],
   ]);
 
-  return [...disableConfig, ...(enablePrettier ? prettierConfig : [])];
+  return [...disableConfig, ...prettierConfig];
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@arphi/eslint-config': link:packages/eslint-config
+
 importers:
 
   .:
@@ -12,7 +15,7 @@ importers:
         specifier: workspace:*
         version: link:packages/commitlint-config
       '@arphi/eslint-config':
-        specifier: workspace:*
+        specifier: link:packages/eslint-config
         version: link:packages/eslint-config
       '@arphi/prettier-config':
         specifier: workspace:*


### PR DESCRIPTION
## Changes

* Replaces the top-level import for `eslint-config-prettier` with a dynamic import to prevent ESLint from trying to load the package even when Prettier is not enabled.
* Explain in the README that this flag might not be needed even when using Prettier

The flag doesn't seem useful right now... Without it I don't have conflicts in an Astro project for example and the `eslint-config-prettier` package disable some rules that aren't causing problems. So perhaps, I should remove this flag completely in the future (it would be a breaking change) or at least remove the `eslint-config-prettier` package and manually disable the conflicting rules if any.

## Tests

Manually using `pnpm link` on another project.

## Docs

* Updates the README regarding Prettier
* Adds a changeset.