### PR TITLE
fix(commitlint-config): disable subject-case rule

### DIFF
--- a/.changeset/rotten-beans-appear.md
+++ b/.changeset/rotten-beans-appear.md
@@ -1,0 +1,7 @@
+---
+"@arphi/commitlint-config": patch
+---
+
+Disables the rule enforcing a case for the subject.
+
+The previous values was causing issue with capital letters with some words or depending on their position. This seems to be a known issue according the commitlint repository. So the rule is now disabled and capital letters are now allowed in the subject regardless of their position.

--- a/packages/commitlint-config/index.js
+++ b/packages/commitlint-config/index.js
@@ -32,11 +32,7 @@ export default {
     "scope-max-length": [RuleConfigSeverity.Disabled],
     "scope-min-length": [RuleConfigSeverity.Disabled],
     "signed-off-by": [RuleConfigSeverity.Disabled],
-    "subject-case": [
-      RuleConfigSeverity.Error,
-      "always",
-      ["camel-case", "lower-case", "sentence-case"],
-    ],
+    "subject-case": [RuleConfigSeverity.Disabled],
     "subject-empty": [RuleConfigSeverity.Error, "never"],
     "subject-full-stop": [RuleConfigSeverity.Error, "never", "."],
     "subject-max-length": [RuleConfigSeverity.Disabled],


### PR DESCRIPTION
## Changes

Disables the rule enforcing a case for the subject.

The previous values was causing issue with capital letters with some words or depending on their position. This seems to be a known issue according to multiple issues opened in the commitlint repository. So the rule is now disabled and capital letters are allowed in the subject regardless of their position.

## Tests

Manually.

## Docs

N/A