### PR TITLE
feat(eslint-config): sort imports in ascending alphabetical order

### DIFF
--- a/.changeset/six-months-punch.md
+++ b/.changeset/six-months-punch.md
@@ -1,0 +1,21 @@
+---
+"@arphi/eslint-config": minor
+---
+
+Enables ascending alphabetical sorting for imports.
+
+Imports sorted in ascending alphabetical order are often easier to visually analyze, as sibling modules would be side by side in a long list of imports.
+
+Previously, the following order wasn't an issue:
+
+```ts
+import type { Linter } from "eslint";
+import type { TSESLint } from "@typescript-eslint/utils";
+```
+
+Now, it will be reported as an auto-fixable error and the fixed order will be:
+
+```ts
+import type { TSESLint } from "@typescript-eslint/utils";
+import type { Linter } from "eslint";
+```

--- a/packages/eslint-config/src/configs/imports.ts
+++ b/packages/eslint-config/src/configs/imports.ts
@@ -78,6 +78,11 @@ export function imports(rulesOverrides: RulesOverrides = {}): Config[] {
         "import-x/order": [
           "error",
           {
+            alphabetize: {
+              order: "asc",
+              orderImportKind: "asc",
+              caseInsensitive: true,
+            },
             groups: ["builtin", "external", "parent", "sibling", "index"],
           },
         ],

--- a/packages/eslint-config/src/types/index.ts
+++ b/packages/eslint-config/src/types/index.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import type { TSESLint } from "@typescript-eslint/utils";
+import type { Linter } from "eslint";
 
 export type Config = Omit<TSESLint.FlatConfig.Config, "plugins"> & {
   // Relax type because some plugins do not have correct type.


### PR DESCRIPTION
Imports sorted in ascending alphabetical order are often easier to visually analyze, as sibling modules would be side by side in a long list of imports.

I find the following easier to parse:
```ts
import Button from "../../atoms/button/button.astro";
import Heading from "../../atoms/heading/heading.astro";
import Img from "../../atoms/img/img.astro";
import Collapsible from "../../molecules/collapsible/collapsible.astro";
```

Than:
```ts
import Img from "../../atoms/img/img.astro";
import Collapsible from "../../molecules/collapsible/collapsible.astro";
import Heading from "../../atoms/heading/heading.astro";
import Button from "../../atoms/button/button.astro";
```

Because imported components (in this example) are correctly grouped by type (atoms, molecules), in ascending order.

## Changes

Configures the `alphabetize` option of the `import-x/order` rule.

## Tests

Manually.

## Docs

Changeset added.