### PR TITLE
build(deps,tsconfig): revert typescript bump

### DIFF
--- a/.changeset/brown-mice-ring.md
+++ b/.changeset/brown-mice-ring.md
@@ -3,7 +3,6 @@
 "@arphi/eslint-config": patch
 "@arphi/prettier-config": patch
 "@arphi/stylelint-config": patch
-"@arphi/tsconfig": patch
 ---
 
 Bump dependencies.

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -38,6 +38,6 @@
     "dev": "tsc --watch"
   },
   "devDependencies": {
-    "typescript": "^5.9.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ importers:
   packages/tsconfig:
     devDependencies:
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
+        specifier: ~5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -6676,7 +6676,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.2: {}
+  typescript@5.9.2:
+    optional: true
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## Changes

Since I'd like to keep all the packages compatible, the `tsconfig` package should not bump `typescript`: `typescript-eslint` is not yet compatible with 5.9.0! This PR reverts the bump and removes `tsconfig` from the changeset.

## Tests

N/A

## Docs

Remove `tsconfig` from changeset.