### PR TITLE
feat(eslint-config): disable the ESLint `one-var` rule

### DIFF
--- a/.changeset/loud-meals-send.md
+++ b/.changeset/loud-meals-send.md
@@ -1,0 +1,19 @@
+---
+"@arphi/eslint-config": minor
+---
+
+Disables the ESLint [`one-var`](https://eslint.org/docs/latest/rules/one-var) rule.
+
+This rule is too restrictive to be enable by default and has been disabled in this new version. If you were relying on it, you can enable it yourself in your ESLint config file using `overrides`:
+
+```js
+import arphi from "@arphi/eslint-config";
+
+export default arphi({
+  overrides: {
+    javascript: {
+      "one-var": ["error", { initialized: "never", uninitialized: "always" }],
+    },
+  },
+});
+```

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -352,7 +352,7 @@ export function javascript(rulesOverrides: RulesOverrides = {}): Config[] {
             ignoreConstructors: false,
           },
         ],
-        "one-var": ["error", { initialized: "never", uninitialized: "always" }],
+        "one-var": "off",
         "operator-assignment": "off",
         "prefer-arrow-callback": [
           "error",


### PR DESCRIPTION
## Changes

Disables the ESLint [`one-var`](https://eslint.org/docs/latest/rules/one-var) rule.

## Docs

Changeset added.