### PR TITLE
docs: reword a changeset

### DIFF
--- a/.changeset/smooth-vans-shave.md
+++ b/.changeset/smooth-vans-shave.md
@@ -6,4 +6,4 @@
 "@arphi/tsconfig": patch
 ---
 
-These packages are now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
+This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).


### PR DESCRIPTION
## Changes

Replaces plural usage with singular in a changeset: contrarily to authoring-time, an individual changelog per package is generated so "these packages" sounds wrong.