### PR TITLE
Revert "ci: new release candidate"

### DIFF
--- a/.changeset/proud-humans-rush.md
+++ b/.changeset/proud-humans-rush.md
@@ -1,0 +1,18 @@
+---
+"@arphi/eslint-config": minor
+---
+
+Adds new rules to the `jsdoc` preset.
+
+The `eslint-plugin-jsdoc` has been bumped to `61.1.4`. The `v61` brings some new rules which has been added to this package and configured to raised an error:
+
+- [`jsdoc/ts-method-signature-style`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-method-signature-style.md#readme)
+- [`jsdoc/ts-no-empty-object-type`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-empty-object-type.md#readme)
+- [`jsdoc/ts-no-unnecessary-template-expression`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-unnecessary-template-expression.md#readme)
+- [`jsdoc/ts-prefer-function-type`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-prefer-function-type.md#readme)
+
+#### What you need to do
+
+If you're not using the `jsdoc` preset, no updates are required.
+
+If you're using the `jsdoc` preset, you might need to fix new errors in your codebase or to disable those rules in your configuration file.

--- a/.changeset/smooth-vans-shave.md
+++ b/.changeset/smooth-vans-shave.md
@@ -1,0 +1,9 @@
+---
+"@arphi/commitlint-config": patch
+"@arphi/eslint-config": patch
+"@arphi/prettier-config": patch
+"@arphi/stylelint-config": patch
+"@arphi/tsconfig": patch
+---
+
+This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).

--- a/.changeset/twenty-gifts-flash.md
+++ b/.changeset/twenty-gifts-flash.md
@@ -1,0 +1,14 @@
+---
+"@arphi/eslint-config": patch
+---
+
+Updates dependencies.
+
+- `@eslint-react/eslint-plugin` to `2.2`
+- `@eslint/js` to `9.38.0`
+- `@types/node` `24.8.1`
+- `@typescript-eslint/parser` to `8.46.1`
+- `@typescript-eslint/utils` to `8.46.1`
+- `@vitest/eslint-plugin` to `1.3.23`
+- `eslint` to `9.38.0`
+- `typescript-eslint` to `8.46.1`

--- a/packages/commitlint-config/CHANGELOG.md
+++ b/packages/commitlint-config/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @arphi/commitlint-config
 
-## 1.0.5
-
-### Patch Changes
-
-- 97450e5: This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
-
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arphi/commitlint-config",
   "description": "The shared commitlint configuration for my projects.",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "license": "MIT",
   "keywords": [
     "commitlint",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,36 +1,5 @@
 # @arphi/eslint-config
 
-## 2.3.0
-
-### Minor Changes
-
-- 67baf5f: Adds new rules to the `jsdoc` preset.
-
-  The `eslint-plugin-jsdoc` has been bumped to `61.1.4`. The `v61` brings some new rules which has been added to this package and configured to raised an error:
-  - [`jsdoc/ts-method-signature-style`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-method-signature-style.md#readme)
-  - [`jsdoc/ts-no-empty-object-type`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-empty-object-type.md#readme)
-  - [`jsdoc/ts-no-unnecessary-template-expression`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-unnecessary-template-expression.md#readme)
-  - [`jsdoc/ts-prefer-function-type`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-prefer-function-type.md#readme)
-
-  #### What you need to do
-
-  If you're not using the `jsdoc` preset, no updates are required.
-
-  If you're using the `jsdoc` preset, you might need to fix new errors in your codebase or to disable those rules in your configuration file.
-
-### Patch Changes
-
-- 97450e5: This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
-- 0b820b6: Updates dependencies.
-  - `@eslint-react/eslint-plugin` to `2.2`
-  - `@eslint/js` to `9.38.0`
-  - `@types/node` `24.8.1`
-  - `@typescript-eslint/parser` to `8.46.1`
-  - `@typescript-eslint/utils` to `8.46.1`
-  - `@vitest/eslint-plugin` to `1.3.23`
-  - `eslint` to `9.38.0`
-  - `typescript-eslint` to `8.46.1`
-
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arphi/eslint-config",
   "description": "The shared ESLint configuration for my projects.",
-  "version": "2.3.0",
+  "version": "2.2.1",
   "license": "MIT",
   "keywords": [
     "eslint",

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @arphi/prettier-config
 
-## 1.0.2
-
-### Patch Changes
-
-- 97450e5: This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
-
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arphi/prettier-config",
   "description": "The shared Prettier configuration for my projects.",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "license": "MIT",
   "keywords": [
     "prettier",

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @arphi/stylelint-config
 
-## 1.0.2
-
-### Patch Changes
-
-- 97450e5: This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
-
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arphi/stylelint-config",
   "description": "The shared Stylelint configuration for my projects.",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "license": "MIT",
   "keywords": [
     "stylelint",

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @arphi/tsconfig
 
-## 1.0.1
-
-### Patch Changes
-
-- 97450e5: This package is now published using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers).
-
 ## 1.0.0
 
 ### Major Changes

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arphi/tsconfig",
   "description": "The shared Typescript configuration for my projects.",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "license": "MIT",
   "keywords": [
     "typescript",


### PR DESCRIPTION
Reverts ArmandPhilippot/configs#63

I did broke something. Not sure what though. Checking other packages almost everything seem the same. Maybe I need to use npm instead of pnpm to publish?