### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: pnpm
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: pnpm i

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 20
+          node-version: 24
           package-manager-cache: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Changes

* Bumps Node.js and Node.js action versions
* Consistency in workflow files

And mostly: trying to fix release errors since #64 (actually I don't see anything wrong, so it's probably a settings error)... or maybe this is because of:
 > Make sure your GitHub workflow is using Node.js v24.8.0 or higher for the publish step.
 > https://e18e.dev/docs/publishing#setting-up-trusted-publishing
 
 I though seeing another repo using a lower version of Node... but let's try that!
 
 Edit: in case someone finds this, this was the culprit! 🎉 