### PR TITLE
fix(renovate): remove noisy presets from the Renovate config

### DIFF
--- a/.changeset/fresh-trees-call.md
+++ b/.changeset/fresh-trees-call.md
@@ -1,0 +1,19 @@
+---
+"@arphi/renovate-config": patch
+---
+
+Prevents lock file maintenance PR creation.
+
+A PR was successfully created but, because of `security:minimumReleaseAgeNpm`, this was never mergeable. This preset has been removed from the default config to prevent an immortal PR living forever in your repository.
+
+If you want to keep the old behavior, you can add `:maintainLockFilesWeekly` back to your config extends:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>ArmandPhilippot/configs//packages/renovate-config/default",
+    ":maintainLockFilesWeekly"
+  ]
+}
+```

--- a/.changeset/tangy-rings-read.md
+++ b/.changeset/tangy-rings-read.md
@@ -1,0 +1,19 @@
+---
+"@arphi/renovate-config": patch
+---
+
+Prevents PR deduplication because of majors.
+
+The `:separateMultipleMajorReleases` preset has been removed from the configuration to prevent noisy PRs. For example, Renovate would create a PR for `@eslint-react/eslint-plugin` to v3, another one to v4, and so on.
+
+If you want to keep the old behavior, you can add `:separateMultipleMajorReleases` back to your config extends:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>ArmandPhilippot/configs//packages/renovate-config/default",
+    ":separateMultipleMajorReleases"
+  ]
+}
+```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "json.schemaDownload.trustedDomains": {
+    "https://docs.renovatebot.com/renovate-schema.json": true
+  }
+}

--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -4,11 +4,13 @@ My shareable Renovate configuration.
 
 ## Usage
 
-In your Renovate configuration file (e.g., `.github/renovate.json`), add the config path to `extends`:
+In your Renovate configuration file (e.g., `renovate.json`), add the config path to `extends`:
 
 ```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ArmandPhilippot/configs//packages/renovate-config"]
+  "extends": [
+    "github>ArmandPhilippot/configs//packages/renovate-config/default"
+  ]
 }
 ```

--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -5,7 +5,6 @@
     ":configMigration",
     ":disableDependencyDashboard",
     ":docker",
-    ":maintainLockFilesWeekly",
     ":semanticCommits",
     ":semanticCommitType(ci)",
     ":separateMultipleMajorReleases",

--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -7,7 +7,6 @@
     ":docker",
     ":semanticCommits",
     ":semanticCommitType(ci)",
-    ":separateMultipleMajorReleases",
     ":widenPeerDependencies",
     "docker:pinDigests",
     "group:drupal-core",


### PR DESCRIPTION
## Changes

* Fixes the config path in the `README`
* Removes `:maintainLockFilesWeekly` because it doesn't seem to work with `security:minimumReleaseAgeNpm`.
* Removes `:separateMultipleMajorReleases` because this is really too noisy:

<img width="649" height="198" alt="image" src="https://github.com/user-attachments/assets/f80d76ad-448e-4518-b048-1c124bdd3c38" />
