### PR TITLE
fix: remove a deprecated ESLint rule

### DIFF
--- a/.changeset/frank-eels-drum.md
+++ b/.changeset/frank-eels-drum.md
@@ -10,6 +10,10 @@ You may see new lint results: `unicorn` now inherits many rules from [`eslint-pl
 
 Two new ESLint core rules are now enabled: [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars) and [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error).
 
+#### Comments
+
+The deprecated [`@eslint-community/eslint-comments/no-unused-disable`](https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html) rule has been removed. Unused `eslint-disable` comments are still reported via the enabled ESLint's `linterOptions.reportUnusedDisableDirectives` option, which is already enabled.
+
 #### Unicorn
 
 The following rules were removed or renamed upstream:

--- a/packages/eslint-config/src/configs/comments.ts
+++ b/packages/eslint-config/src/configs/comments.ts
@@ -16,7 +16,6 @@ export function comments(rulesOverrides: RulesOverrides = {}): Config[] {
       },
       rules: {
         ...commentsPlugin.configs.recommended.rules,
-        "@eslint-community/eslint-comments/no-unused-disable": "error",
         "@eslint-community/eslint-comments/require-description": [
           "warn",
           { ignore: ["eslint-enable"] },


### PR DESCRIPTION
## Changes

Removes the [`@eslint-community/eslint-comments/no-unused-disable`](https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html) rule. It has been deprecated in the plugin and the equivalent ESLint feature is already enabled.

## Tests

Everything green.

## Docs

Updates on changeset.