### PR TITLE
feat(eslint-config): add a `monorepo` flag to disable flaky rules

### DIFF
--- a/.changeset/cool-lizards-dance.md
+++ b/.changeset/cool-lizards-dance.md
@@ -1,0 +1,17 @@
+---
+"@arphi/eslint-config": minor
+---
+
+Adds a `monorepo` flag that disables rules known to misbehave in a monorepo/workspace layout.
+
+This is useful in cases where ESLint is run from the root of a monorepo/workspace, but the `package.json` for a nested package is not visible to ESLint's process.
+
+For example, [`jsdoc/imports-as-dependencies`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/imports-as-dependencies.md) is not able to see dependencies declared in a nested package's own `package.json` and reports false positives.
+
+If you are working in a monorepo/workspace and linting from the root, enable this flag to disable the affected rules:
+
+```js
+import arphi from "@arphi/eslint-config";
+
+export default arphi({ monorepo: true });
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import arphi from "@arphi/eslint-config";
 
 export default arphi({
   jsdoc: true,
+  monorepo: true,
   prettier: true,
   tests: true,
   typescript: true,

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -18,7 +18,7 @@ import arphi from "@arphi/eslint-config";
 export default arphi();
 ```
 
-This will enable rules for JavaScript, ESLint comments and imports. Optionally, you can enable [additional presets](#optional-presets) to extend the configuration.
+This will enable rules for JavaScript, ESLint comments and imports. Optionally, you can enable [additional presets](#optional-presets) to extend the configuration, or [flags](#optional-flags) to adapt it to a specific context.
 
 ## Optional presets
 
@@ -86,22 +86,6 @@ The JSDoc preset uses the following plugins, you might need to install them:
 npm i -D eslint-plugin-jsdoc
 ```
 
-### Prettier
-
-Some rules may conflict with [Prettier](https://prettier.io/). If you use Prettier and encounter conflicts, instead of manually overriding the rules, you can enable the Prettier flag:
-
-```js
-import arphi from "@arphi/eslint-config";
-
-export default arphi({ prettier: true });
-```
-
-The Prettier preset uses the following plugin, you might need to install it:
-
-```sh
-npm i -D eslint-config-prettier
-```
-
 ### Tests
 
 To enable ESLint for your test files written with [Vitest](https://vitest.dev/), pass the following flag:
@@ -119,6 +103,40 @@ npm i -D @vitest/eslint-plugin eslint-plugin-no-only-tests
 ```
 
 When you write TypeScript with Vitest, you want to also enable the [Typescript](#typescript) preset.
+
+## Optional flags
+
+Unlike the presets above, these flags don't add new rules. They adjust the existing rules for a specific context. As with presets, you may need to restart the ESLint server in your editor after enabling one.
+
+### Prettier
+
+Some rules may conflict with [Prettier](https://prettier.io/). If you use Prettier and encounter conflicts, instead of manually overriding the rules, you can enable the Prettier flag:
+
+```js
+import arphi from "@arphi/eslint-config";
+
+export default arphi({ prettier: true });
+```
+
+This flag uses the following plugin, you might need to install it:
+
+```sh
+npm i -D eslint-config-prettier
+```
+
+### Monorepo
+
+Some rules only look at the `package.json` of the directory ESLint was started from, which doesn't work well in a monorepo/workspace.
+
+If you lint from the workspace root, enable this flag to disable the affected rules:
+
+```js
+import arphi from "@arphi/eslint-config";
+
+export default arphi({ monorepo: true });
+```
+
+For example, [`jsdoc/imports-as-dependencies`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/imports-as-dependencies.md) only reads `process.cwd()/package.json`, so it can't see a dependency declared in a nested package's own `package.json`.
 
 ## Customizing the configuration
 

--- a/packages/eslint-config/src/configs/monorepo.test.ts
+++ b/packages/eslint-config/src/configs/monorepo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { lintCode } from "../../test/helpers/lint";
+import { jsdoc } from "./jsdoc";
+import { monorepo } from "./monorepo";
+
+describe("monorepo preset", () => {
+  it("resolves cleanly (no removed/renamed rule, no fatal parse error)", async () => {
+    expect.assertions(1);
+
+    const config = monorepo();
+    const code = "const a = 1;\n";
+    const { messages } = await lintCode(code, config, "sample.js");
+
+    expect(messages.filter((message) => message.fatal)).toStrictEqual([]);
+  });
+
+  it("silences jsdoc/imports-as-dependencies, which only checks the root package.json", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- assertion count
+    expect.assertions(2);
+
+    const code =
+      "/** @type {import('lodash').LoDashStatic} */\nconst a = {};\n";
+    const jsdocConfig = await jsdoc();
+    const [withoutMonorepo, withMonorepo] = await Promise.all([
+      lintCode(code, jsdocConfig, "sample.js"),
+      lintCode(code, [...jsdocConfig, ...monorepo()], "sample.js"),
+    ]);
+
+    expect(withoutMonorepo.messages.map((message) => message.ruleId)).toContain(
+      "jsdoc/imports-as-dependencies"
+    );
+    expect(
+      withMonorepo.messages.map((message) => message.ruleId)
+    ).not.toContain("jsdoc/imports-as-dependencies");
+  });
+
+  it("applies rule overrides", () => {
+    expect.assertions(1);
+
+    const config = monorepo({
+      "jsdoc/imports-as-dependencies": "warn",
+    });
+
+    expect(config[0]?.rules?.["jsdoc/imports-as-dependencies"]).toBe("warn");
+  });
+});

--- a/packages/eslint-config/src/configs/monorepo.ts
+++ b/packages/eslint-config/src/configs/monorepo.ts
@@ -1,0 +1,24 @@
+import type { Config, RulesOverrides } from "../types";
+
+/**
+ * Configure the rules known to misbehave in a monorepo/workspace layout.
+ *
+ * @param {RulesOverrides} [rulesOverrides] - The rules to override.
+ * @returns {Config[]} The monorepo configuration.
+ */
+export function monorepo(rulesOverrides: RulesOverrides = {}): Config[] {
+  return [
+    {
+      name: "arphi/monorepo",
+      rules: {
+        /*
+         * Reads `process.cwd()/package.json` once per run, so from a
+         * workspace root it can't see dependencies declared in a package's
+         * own package.json and reports false positives.
+         */
+        "jsdoc/imports-as-dependencies": "off",
+        ...rulesOverrides,
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/src/index.test.ts
+++ b/packages/eslint-config/src/index.test.ts
@@ -45,6 +45,7 @@ describe("arphi factory", () => {
         "arphi/jsdoc",
         "arphi/tests",
         "arphi/prettier",
+        "arphi/monorepo",
       ])
     );
   });
@@ -56,6 +57,7 @@ describe("arphi factory", () => {
     ["jsdoc", "arphi/jsdoc"],
     ["tests", "arphi/tests"],
     ["prettier", "arphi/prettier"],
+    ["monorepo", "arphi/monorepo"],
   ] as const)("includes %s's config when enabled", async (flag, name) => {
     expect.assertions(1);
 
@@ -97,6 +99,17 @@ describe("arphi factory", () => {
     const prettierIndex = names.indexOf("arphi/prettier");
 
     expect(prettierIndex).toBeGreaterThan(disablesIndex);
+  });
+
+  it("appends monorepo after the disables footer", async () => {
+    expect.assertions(1);
+
+    const config = await arphi({ monorepo: true });
+    const names = configNames(config);
+    const disablesIndex = names.indexOf("arphi/disables/cjs");
+    const monorepoIndex = names.indexOf("arphi/monorepo");
+
+    expect(monorepoIndex).toBeGreaterThan(disablesIndex);
   });
 
   it("places user configs between the optional presets and the footer", async () => {

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -5,6 +5,7 @@ import { ignores as ignoresConfig } from "./configs/ignores";
 import { imports } from "./configs/imports";
 import { javascript } from "./configs/javascript";
 import { jsdoc } from "./configs/jsdoc";
+import { monorepo } from "./configs/monorepo";
 import { prettier } from "./configs/prettier";
 import { react } from "./configs/react";
 import { tests } from "./configs/tests";
@@ -48,12 +49,12 @@ function loadRequiredConfigs(
 /**
  * Load the optional configurations.
  *
- * @param {Omit<Partial<OptionalConfigs>, "prettier">} configs - Configs to enable.
+ * @param {Omit<Partial<OptionalConfigs>, "prettier" | "monorepo">} configs - Configs to enable.
  * @param {ConfigOptions["overrides"]} overrides - The config overrides.
  * @returns {Promise<Config[]>} The optional configurations.
  */
 async function loadOptionalConfigs(
-  configs: Omit<Partial<OptionalConfigs>, "prettier">,
+  configs: Omit<Partial<OptionalConfigs>, "prettier" | "monorepo">,
   overrides: ConfigOptions["overrides"]
 ): Promise<Config[]> {
   const configLoaders: [
@@ -79,18 +80,21 @@ async function loadOptionalConfigs(
  * Load the configs that should appear last.
  *
  * @param {ConfigOptions["prettier"]} enablePrettier - Activate Prettier or not.
+ * @param {ConfigOptions["monorepo"]} isMonorepo - Disable monorepo-flaky rules or not.
  * @param {ConfigOptions["overrides"]} overrides - The config overrides.
  * @returns {Promise<Config[]>} The footer configurations.
  */
 async function loadFooterConfigs(
   enablePrettier: boolean,
+  isMonorepo: boolean,
   overrides: ConfigOptions["overrides"]
 ): Promise<Config[]> {
+  const monorepoConfig = isMonorepo ? monorepo(overrides?.monorepo) : [];
   const prettierConfig = enablePrettier
     ? await prettier(overrides?.prettier)
     : [];
 
-  return [...disables(), ...prettierConfig];
+  return [...disables(), ...monorepoConfig, ...prettierConfig];
 }
 
 /**
@@ -104,6 +108,7 @@ export default async function arphi(
   {
     ignores,
     overrides,
+    monorepo: isMonorepo = false,
     prettier: enablePrettier = false,
     ...optional
   }: ConfigOptions = {},
@@ -111,7 +116,7 @@ export default async function arphi(
 ): Promise<Config[]> {
   const [optionalConfigs, footerConfigs] = await Promise.all([
     loadOptionalConfigs(optional, overrides),
-    loadFooterConfigs(enablePrettier, overrides),
+    loadFooterConfigs(enablePrettier, isMonorepo, overrides),
   ]);
 
   return [

--- a/packages/eslint-config/src/types/index.ts
+++ b/packages/eslint-config/src/types/index.ts
@@ -16,7 +16,11 @@ export type OptionalConfigs = {
    */
   jsdoc: boolean;
   /**
-   * Enable Prettier configuration.
+   * Disable rules known to misbehave in a monorepo/workspace layout.
+   */
+  monorepo: boolean;
+  /**
+   * Disable rules that conflict with Prettier.
    */
   prettier: boolean;
   /**
@@ -56,6 +60,10 @@ type Overrides = {
    * Override the JSDoc rules.
    */
   jsdoc: RulesOverrides;
+  /**
+   * Override the monorepo rules.
+   */
+  monorepo: RulesOverrides;
   /**
    * Override the Prettier rules.
    */


### PR DESCRIPTION
## Changes

Adds a new `monorepo` flag to the ESLint config to disable rules that do not work well in a monorepo. This might be because the issue is not yet reported or because of a long-standing issue.

## Tests

Everything green.

## Docs

- Adds a changeset
- Adds a new section in the README 
- Splits presets and flags in the README